### PR TITLE
Chore/test and production configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 dist/
 node_modules/
+src/rise-data-twitter-config.js
 demo/build/**
 demo/node_modules/**
 coverage/

--- a/config/prod.js
+++ b/config/prod.js
@@ -1,0 +1,3 @@
+export const config = {
+  twitterServiceURL: "https://services-stage.risevision.com/twitter"
+};

--- a/config/test.js
+++ b/config/test.js
@@ -1,0 +1,3 @@
+export const config = {
+  twitterServiceURL: "https://services-stage.risevision.com/twitter"
+};

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "1.0.0",
   "description": "Rise Data Twitter component",
   "scripts": {
-    "prebuild": "eslint .",
+    "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-twitter",
     "build": "polymer build && ./node_modules/rise-common-component/scripts/extract-source.sh rise-data-twitter",
     "pretty": "eslint . --fix",
-    "test": "eslint . && polymer test"
+    "pretest": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh test rise-data-twitter",
+    "test": "polymer test"
   },
   "repository": {
     "type": "git",

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -2,6 +2,7 @@
 
 import { html } from "@polymer/polymer";
 import { RiseElement } from "rise-common-component/src/rise-element.js";
+import { config } from "./rise-data-twitter-config.js";
 import { version } from "./rise-data-twitter-version.js";
 
 export default class RiseDataTwitter extends RiseElement {


### PR DESCRIPTION
## Description
Add configuration scripts for test and production environments. 

## Motivation and Context
Part of tasks for current card. This is based on how configuration is implemented for rise-data-financial. Currently both test and prod configurations are pointing to services-stage.risevision.com.

## How Has This Been Tested?
No runtime changes, but both npm test and npm run build were tested, and configuration file was checked to see it was correctly generated.

## Release Plan:
Not in production.

#### Release Checklist Items Skipped?
N/A
