### PR TITLE
E2e/request tweets

### DIFF
--- a/e2e/rise-data-twitter.html
+++ b/e2e/rise-data-twitter.html
@@ -43,7 +43,7 @@
   </style>
 </head>
 <body>
-<rise-data-twitter id="rise-data-twitter-01" label="Count Down" type="down" date="2050-01-01">
+<rise-data-twitter id="rise-data-twitter-01" account="RiseVision" maxitems="10">
 </rise-data-twitter>
 
 <div id="twitterData" class="twitterContainer" style="display: none"></div>

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -2,10 +2,15 @@
 
 import { html } from "@polymer/polymer";
 import { RiseElement } from "rise-common-component/src/rise-element.js";
+import { CacheMixin } from "rise-common-component/src/cache-mixin.js";
+import { FetchMixin } from "rise-common-component/src/fetch-mixin.js";
+
 import { config } from "./rise-data-twitter-config.js";
 import { version } from "./rise-data-twitter-version.js";
 
-export default class RiseDataTwitter extends RiseElement {
+const fetchBase = CacheMixin(RiseElement);
+
+export default class RiseDataTwitter extends FetchMixin(fetchBase) {
   static get template() {
     // TODO: this is temporary for skeleton
     return html`<h1>Rise Data Twitter component</h1>`;
@@ -91,7 +96,7 @@ export default class RiseDataTwitter extends RiseElement {
 
   _getUrl() {
     const companyId = RisePlayerConfiguration.getCompanyId();
-    const username = this.account && this.account.indexOf('@') === 0 ?
+    const username = this.account && this.account.indexOf("@") === 0 ?
       this.account.substring(1) : this.account;
 
     return `${
@@ -103,6 +108,25 @@ export default class RiseDataTwitter extends RiseElement {
     }&count=${
       this.maxitems
     }`;
+  }
+
+  _loadTweets() {
+    if (!this._initialStart && this.account) {
+      super.fetch(this._getUrl(), {
+        headers: { "X-Requested-With": "rise-data-twitter" }
+      });
+    }
+  }
+
+  _handleResponse(response) {
+    return response.json()
+      .then( json => {
+        console.log(json); // TODO: send as event
+      });
+  }
+
+  _handleError(error) {
+    console.error(error); // TODO: handle properly
   }
 
 }

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -111,7 +111,7 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
   }
 
   _loadTweets() {
-    if (!this._initialStart && this.account) {
+    if (this.account) {
       super.fetch(this._getUrl(), {
         headers: { "X-Requested-With": "rise-data-twitter" }
       });

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -51,6 +51,17 @@ export default class RiseDataTwitter extends RiseElement {
 
     this.addEventListener( "rise-presentation-play", () => this._reset());
     this.addEventListener( "rise-presentation-stop", () => this._stop());
+
+    super.initFetch({
+      refresh: 1000 * 60 * 30, // it will be overriden by service response headers
+      retry: 1000 * 60 * 5,
+      cooldown: 1000 * 60 * 10
+    }, this._handleResponse, this._handleError);
+
+    super.initCache({
+      name: this.tagName.toLowerCase(),
+      expiry: -1
+    });
   }
 
   _reset() {
@@ -61,7 +72,7 @@ export default class RiseDataTwitter extends RiseElement {
   }
 
   _start() {
-    // TODO: coming soon ..
+    this._loadTweets();
   }
 
   _stop() {
@@ -77,6 +88,23 @@ export default class RiseDataTwitter extends RiseElement {
       this._start();
     }
   }
+
+  _getUrl() {
+    const companyId = RisePlayerConfiguration.getCompanyId();
+    const username = this.account && this.account.indexOf('@') === 0 ?
+      this.account.substring(1) : this.account;
+
+    return `${
+      config.twitterServiceURL
+    }/get-tweets?companyId=${
+      companyId
+    }&username=${
+      username
+    }&count=${
+      this.maxitems
+    }`;
+  }
+
 }
 
 customElements.define("rise-data-twitter", RiseDataTwitter);

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -15,7 +15,8 @@
 
     <script type="text/javascript">
       RisePlayerConfiguration = {
-        isConfigured: () => true
+        isConfigured: () => true,
+        getCompanyId: () => "xxxx-yyyy"
       };
     </script>
 
@@ -31,7 +32,7 @@
     <script type="module">
       suite("rise-data-twitter", () => {
         let sandbox = sinon.createSandbox();
-        let element, clock, riseElement;
+        let element, clock, riseElement, fetchMixin;
 
         setup(() => {
           RisePlayerConfiguration.Logger = {
@@ -48,7 +49,8 @@
 
           element = fixture("test-block");
 
-          riseElement = element.__proto__.__proto__;
+          fetchMixin = element.__proto__.__proto__;
+          riseElement = element.__proto__.__proto__.__proto__.__proto__;
 
           sandbox.spy(riseElement, '_sendEvent');
           sandbox.stub(riseElement, '_setUptimeError');
@@ -164,6 +166,88 @@
           } );
 
         } );
+
+        suite( "_loadTweets", () => {
+          setup( () => {
+            sandbox.stub(element, "_getUrl").returns("https://service");
+            sandbox.stub(fetchMixin, "fetch");
+          });
+
+          test( "should call fetch if it is not initial start and account is set", () => {
+            element._initialStart = false;
+            element.account = "@RiseVision";
+            sandbox.resetHistory();
+
+            element._loadTweets();
+
+            assert.isTrue(element._getUrl.calledOnce);
+
+            assert.isTrue(fetchMixin.fetch.calledOnce);
+            assert.equal(fetchMixin.fetch.lastCall.args[0], "https://service");
+          });
+
+          test( "should not call fetch if it's initial start", () => {
+            element._initialStart = true;
+            element.account = "@RiseVision";
+            sandbox.resetHistory();
+
+            element._loadTweets();
+
+            assert.isFalse(element._getUrl.called);
+            assert.isFalse(fetchMixin.fetch.called);
+          });
+
+          test( "should not call fetch if account is not set", () => {
+            element._initialStart = false;
+
+            element._loadTweets();
+
+            assert.isFalse(element._getUrl.called);
+            assert.isFalse(fetchMixin.fetch.called);
+          });
+        });
+
+        suite( "_getUrl", () => {
+          test( "should build URL", () => {
+            element.account = "RiseVision";
+
+            const url = element._getUrl();
+
+            assert.equal(url, "https://services-stage.risevision.com/twitter/get-tweets?companyId=xxxx-yyyy&username=RiseVision&count=25");
+          });
+
+          test( "should not include '@' in URL", () => {
+            element.account = "@RiseVision";
+
+            const url = element._getUrl();
+
+            assert.equal(url, "https://services-stage.risevision.com/twitter/get-tweets?companyId=xxxx-yyyy&username=RiseVision&count=25");
+          });
+        });
+
+        suite( "_handleResponse", () => {
+          test( "should handle response", () => {
+            const json = sandbox.stub().resolves({});
+
+            return element._handleResponse({json})
+            .then(() => {
+              assert.isTrue(json.calledOnce);
+            });
+          });
+        });
+
+        suite( "_handleError", () => {
+          setup( () => {
+            sandbox.stub( console, "error" );
+          });
+
+          test( "should handle error", () => {
+            element._handleError(new Error("error"));
+
+            assert.isTrue( console.error.calledOnce );
+          });
+        });
+
       });
     </script>
   </body>

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -173,8 +173,7 @@
             sandbox.stub(fetchMixin, "fetch");
           });
 
-          test( "should call fetch if it is not initial start and account is set", () => {
-            element._initialStart = false;
+          test( "should call fetch if account is set", () => {
             element.account = "@RiseVision";
             sandbox.resetHistory();
 
@@ -186,20 +185,7 @@
             assert.equal(fetchMixin.fetch.lastCall.args[0], "https://service");
           });
 
-          test( "should not call fetch if it's initial start", () => {
-            element._initialStart = true;
-            element.account = "@RiseVision";
-            sandbox.resetHistory();
-
-            element._loadTweets();
-
-            assert.isFalse(element._getUrl.called);
-            assert.isFalse(fetchMixin.fetch.called);
-          });
-
           test( "should not call fetch if account is not set", () => {
-            element._initialStart = false;
-
             element._loadTweets();
 
             assert.isFalse(element._getUrl.called);


### PR DESCRIPTION
## Description
Fetch tweets ( using fetch-mixin )

## Motivation and Context
Part of execution strategy.

Tweets and errors are just written to console. Future PRs will add more handling.

## How Has This Been Tested?
Tested with example template running in this schedule: https://apps-stage-9.risevision.com/schedules/details/d1b7040b-81ea-4633-bb58-a0b2f72f19bc?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

Tweets are printed to console:
![tweets](https://user-images.githubusercontent.com/33162690/75920790-ad267100-5e25-11ea-9fbf-a500c48fb983.png)

## Release Plan:
Not in production

#### Release Checklist Items Skipped?
N/A
