### PR TITLE
E2e/rename account property

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-`rise-data-twitter` is a Polymer 3 Web Component that provides twits from a configurable Twitter account.
+`rise-data-twitter` is a Polymer 3 Web Component that provides twits from a configurable Twitter username.
 
 ## Usage
 
@@ -29,6 +29,8 @@ This component receives the following list of attributes:
 - **id**: (string): Unique HTMLElement id.
 - **label**: (string): Assigns the label to use for the instance of the component in Template Editor.
 - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the Template Editor.
+- **username**: ( string / optional ): The default username for which the tweets will be requested.
+- **maxitems**: ( integer / optional ): The default number of items to request. Defaults to 25.
 
 This component does not support PUD; it will need to be handled by Designers on a per Template basis.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-`rise-data-twitter` is a Polymer 3 Web Component that provides twits from a configurable Twitter username.
+`rise-data-twitter` is a Polymer 3 Web Component that provides tweets from a configurable Twitter account.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,13 @@ Since this is not a visual component, a listener needs to be registered to proce
 
 ### Attributes
 
-_More attributes to be defined_
-
 This component receives the following list of attributes:
 
 - **id**: (string): Unique HTMLElement id.
 - **label**: (string): Assigns the label to use for the instance of the component in Template Editor.
 - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the Template Editor.
 - **username**: ( string / optional ): The default username for which the tweets will be requested.
-- **maxitems**: ( integer / optional ): The default number of items to request. Defaults to 25.
+- **maxitems**: ( integer / optional ): The default number of tweets to request. Defaults to 25.
 
 This component does not support PUD; it will need to be handled by Designers on a per Template basis.
 

--- a/e2e/rise-data-twitter.html
+++ b/e2e/rise-data-twitter.html
@@ -43,7 +43,7 @@
   </style>
 </head>
 <body>
-<rise-data-twitter id="rise-data-twitter-01" account="RiseVision" maxitems="10">
+<rise-data-twitter id="rise-data-twitter-01" username="RiseVision" maxitems="10">
 </rise-data-twitter>
 
 <div id="twitterData" class="twitterContainer" style="display: none"></div>

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -22,7 +22,7 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
        * The Twitter handle whose content will be retrieved. The @ symbol may be omitted.
        * If not provided at design time, users need to provide it on Attribute Editor.
        */
-      account: {
+      username: {
         type: String,
         value: ""
       },
@@ -40,7 +40,7 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
   // a comma-separated list of one or more dependencies.
   static get observers() {
     return [
-      "_reset(account, maxitems)"
+      "_reset(username, maxitems)"
     ];
   }
 
@@ -96,8 +96,8 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
 
   _getUrl() {
     const companyId = RisePlayerConfiguration.getCompanyId();
-    const username = this.account && this.account.indexOf("@") === 0 ?
-      this.account.substring(1) : this.account;
+    const username = this.username && this.username.indexOf("@") === 0 ?
+      this.username.substring(1) : this.username;
 
     return `${
       config.twitterServiceURL

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -111,7 +111,7 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
   }
 
   _loadTweets() {
-    if (this.account) {
+    if (this.username) {
       super.fetch(this._getUrl(), {
         headers: { "X-Requested-With": "rise-data-twitter" }
       });

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -195,7 +195,7 @@
 
         suite( "_getUrl", () => {
           test( "should build URL", () => {
-            element.account = "RiseVision";
+            element.username = "RiseVision";
 
             const url = element._getUrl();
 
@@ -203,7 +203,7 @@
           });
 
           test( "should not include '@' in URL", () => {
-            element.account = "@RiseVision";
+            element.username = "@RiseVision";
 
             const url = element._getUrl();
 

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -173,8 +173,8 @@
             sandbox.stub(fetchMixin, "fetch");
           });
 
-          test( "should call fetch if account is set", () => {
-            element.account = "@RiseVision";
+          test( "should call fetch if username is set", () => {
+            element.username = "@RiseVision";
             sandbox.resetHistory();
 
             element._loadTweets();
@@ -185,7 +185,7 @@
             assert.equal(fetchMixin.fetch.lastCall.args[0], "https://service");
           });
 
-          test( "should not call fetch if account is not set", () => {
+          test( "should not call fetch if username is not set", () => {
             element._loadTweets();
 
             assert.isFalse(element._getUrl.called);


### PR DESCRIPTION
## Description
Use correct name for username property.

## Motivation and Context
In all UI, apps and twitter-service we've been using "username", but the component was defining "account" as the property. This fixes that so it matches other uses.

## How Has This Been Tested?
The updated component was tested in this schedule: https://apps-stage-9.risevision.com/schedules/details/d1b7040b-81ea-4633-bb58-a0b2f72f19bc?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

And it still behaves correctly.

## Release Plan:
Not in production

#### Release Checklist Items Skipped?
N/A
