### PR TITLE
E2e/log as warning or error depending on error response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3494,7 +3494,7 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#aa7ad1a9ecfe9f386321bd790c94219e8e41c695",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#1780326468d0e107c85bc00a859f8b62fad21eb1",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@polymer/test-fixture": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/Rise-Vision/rise-data-twitter/#readme",
   "dependencies": {
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#d792aa0"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.6.0"
   },
   "devDependencies": {
     "@polymer/test-fixture": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/Rise-Vision/rise-data-twitter/#readme",
   "dependencies": {
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.5.2"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#d792aa0"
   },
   "devDependencies": {
     "@polymer/test-fixture": "^4.0.2",

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -250,6 +250,74 @@
           });
         });
 
+        suite( "logTypeForFetchError", () => {
+          test( "should return error type for null error", () => {
+            const eventType = element.logTypeForFetchError();
+
+            assert.equal(eventType, "error");
+          });
+
+          test( "should return error type for error with no status", () => {
+            const eventType = element.logTypeForFetchError({});
+
+            assert.equal(eventType, "error");
+          });
+
+          test( "should return warning type for 403 status", () => {
+            const eventType = element.logTypeForFetchError({ status: 403 });
+
+            assert.equal(eventType, "warning");
+          });
+
+          test( "should return warning type for 429 status", () => {
+            const eventType = element.logTypeForFetchError({ status: 429 });
+
+            assert.equal(eventType, "warning");
+          });
+
+          test( "should return error type for 404 status with no response text", () => {
+            const eventType = element.logTypeForFetchError({ status: 404 });
+
+            assert.equal(eventType, "error");
+          });
+
+          test( "should return warning type for 404 status with username not found", () => {
+            const eventType = element.logTypeForFetchError({
+              status: 404,
+              responseText: "Username not found: 'panchito'"
+            });
+
+            assert.equal(eventType, "warning");
+          });
+
+          test( "should return error type for 404 status with page not found", () => {
+            const eventType = element.logTypeForFetchError({
+              status: 404,
+              responseText: "Page not found"
+            });
+
+            assert.equal(eventType, "error");
+          });
+
+          test( "should return error type for 500 status", () => {
+            const eventType = element.logTypeForFetchError({ status: 500 });
+
+            assert.equal(eventType, "error");
+          });
+
+          test( "should return error type for 400 status", () => {
+            const eventType = element.logTypeForFetchError({ status: 400 });
+
+            assert.equal(eventType, "error");
+          });
+
+          test( "should return error type for 409 status", () => {
+            const eventType = element.logTypeForFetchError({ status: 409 });
+
+            assert.equal(eventType, "error");
+          });
+        });
+
       });
     </script>
   </body>


### PR DESCRIPTION
## Description
Implement logTypeForFetchError to decide which fetch errors are treated as warnings.

## Motivation and Context
See related PR https://github.com/Rise-Vision/rise-common-component/pull/40

Reference to rise-common-component will be fixed before the PR is merged.

## How Has This Been Tested?
See related PR https://github.com/Rise-Vision/rise-common-component/pull/40

## Release Plan:
Not in production.

#### Release Checklist Items Skipped?
N/A
