### PR TITLE
listen to credential updates

### DIFF
--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -28,6 +28,12 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
       maxitems: {
         type: Number,
         value: 25
+      },
+      /**
+       * A timestamp set to the editor so the Preview component can update whenever credentials are updateed.
+       */
+      credentialsUpdated: {
+        type: Number
       }
     };
   }
@@ -36,7 +42,7 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
   // a comma-separated list of one or more dependencies.
   static get observers() {
     return [
-      "_reset(username, maxitems)"
+      "_reset(username, maxitems, credentialsUpdated)"
     ];
   }
 


### PR DESCRIPTION
## Description
Fetch tweets if credentialsUpdated property changes.

## Motivation and Context
Part of preview design

## How Has This Been Tested?
A staged version of the component was used with example-twitter-component template: https://github.com/Rise-Vision/html-template-library/compare/example-twitter-component/staging/test?expand=1

When run against a presentation with no credentials, right after connection the get-tweets request was attempted:

![updated](https://user-images.githubusercontent.com/33162690/77099223-379bd280-69d9-11ea-8b44-67c04583cab0.png)

The request fails with a 403 error because the companyId/presentationId parameter is still not available in preview, but the attempt was requested as expected.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - Not in production
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
N/A
