### PR TITLE
Refactor service request url and params

### DIFF
--- a/e2e/rise-data-twitter.html
+++ b/e2e/rise-data-twitter.html
@@ -30,6 +30,10 @@
     }
   </script>
   <style>
+    body {
+      background-color: lightgray;
+    }
+
     .twitterContainer {
       background-color: lightblue;
       border: solid 1px black;

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -122,7 +122,8 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
 
   _getUrl() {
     const presentationId = RisePlayerConfiguration.getPresentationId(),
-      hash = this._computeHash( presentationId, this.id, this.username );
+      username = this.username && this.username.indexOf("@") === 0 ? this.username.substring(1) : this.username,
+      hash = this._computeHash( presentationId, this.id, username );
 
     return `${
       config.twitterServiceURL

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -121,18 +121,17 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
   }
 
   _getUrl() {
-    const companyId = RisePlayerConfiguration.getCompanyId();
-    const username = this.username && this.username.indexOf("@") === 0 ?
-      this.username.substring(1) : this.username;
+    const presentationId = RisePlayerConfiguration.getPresentationId(),
+      hash = this._computeHash( presentationId, this.id, this.username );
 
     return `${
       config.twitterServiceURL
-    }/get-tweets?companyId=${
-      companyId
-    }&username=${
-      username
-    }&count=${
-      this.maxitems
+    }/get-presentation-tweets?presentationId=${
+      presentationId
+    }&componentId=${
+      this.id
+    }&hash=${
+      hash
     }`;
   }
 

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -216,6 +216,15 @@
 
             assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}`);
           });
+
+          test( "should account for @ character in username and ensure to remove it for computing hash", () => {
+            element.username = "@RiseVision";
+
+            const hashVal = "f073a40c095e19635a4cb6ceeb8a554d0f88f55f",
+              url = element._getUrl();
+
+            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}`);
+          });
         });
 
         suite( "_handleResponse", () => {

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -17,7 +17,7 @@
     <script type="text/javascript">
       RisePlayerConfiguration = {
         isConfigured: () => true,
-        getCompanyId: () => "xxxx-yyyy"
+        getPresentationId: () => "xxxx-yyyy"
       };
     </script>
 
@@ -26,7 +26,7 @@
   <body>
     <test-fixture id="test-block">
       <template>
-        <rise-data-twitter></rise-data-twitter>
+        <rise-data-twitter id="rise-data-twitter-01"></rise-data-twitter>
       </template>
     </test-fixture>
 
@@ -211,17 +211,10 @@
           test( "should build URL", () => {
             element.username = "RiseVision";
 
-            const url = element._getUrl();
+            const hashVal = "f073a40c095e19635a4cb6ceeb8a554d0f88f55f",
+              url = element._getUrl();
 
-            assert.equal(url, "https://services-stage.risevision.com/twitter/get-tweets?companyId=xxxx-yyyy&username=RiseVision&count=25");
-          });
-
-          test( "should not include '@' in URL", () => {
-            element.username = "@RiseVision";
-
-            const url = element._getUrl();
-
-            assert.equal(url, "https://services-stage.risevision.com/twitter/get-tweets?companyId=xxxx-yyyy&username=RiseVision&count=25");
+            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}`);
           });
         });
 


### PR DESCRIPTION
## Description
Get tweets from the newly implemented `get-presentation-tweets` endpoint of our Twitter Service. 

Providing the required _presentation id_, _component id_ and _hash_ to the call. 

Add static background for e2e test template due to recent changes

## Motivation and Context
This is part 2 of 2 part changes to the component to now call the new get-presentation-tweets endpoint instead of get-tweets which has been done for security reasons - we now do not disclose the company id in any request. 

## How Has This Been Tested?
Tested with a staged version of our example twitter template that uses a staged version of the component. 

https://apps-stage-8.risevision.com/templates/edit/f396a646-1523-4a99-8a25-76e46ffda681/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

** NOTE**
@olegrise In testing this I have discovered an issue with our Twitter Service upon initially creating a new template presentation. The request that the component makes for tweets fails, our service responds with 500 _Invalid username in presentation_.  Once changes are made to the template and you publish them, the request is then successful and the template displays data, as you can see in my presentation linked above. 

I have isolated the issue and looking into what options there might be to resolve. The issue is significant, it was overlooked in the design for hiding company id. However, this PR can still be reviewed and merged as there are no issues with the component. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
