### PR TITLE
Add additional useDraft query param to request for tweets

### DIFF
--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -125,7 +125,7 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
       username = this.username && this.username.indexOf("@") === 0 ? this.username.substring(1) : this.username,
       hash = this._computeHash( presentationId, this.id, username );
 
-    let url = `${
+    return `${
       config.twitterServiceURL
     }/get-presentation-tweets?presentationId=${
       presentationId
@@ -133,13 +133,9 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
       this.id
     }&hash=${
       hash
+    }&useDraft=${
+      RisePlayerConfiguration.isPreview()
     }`;
-
-    if (!RisePlayerConfiguration.isPreview()) {
-      url = `${url}&useDraft=false`
-    }
-
-    return url;
   }
 
   _loadTweets() {

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -125,7 +125,7 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
       username = this.username && this.username.indexOf("@") === 0 ? this.username.substring(1) : this.username,
       hash = this._computeHash( presentationId, this.id, username );
 
-    return `${
+    let url = `${
       config.twitterServiceURL
     }/get-presentation-tweets?presentationId=${
       presentationId
@@ -134,6 +134,12 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
     }&hash=${
       hash
     }`;
+
+    if (!RisePlayerConfiguration.isPreview()) {
+      url = `${url}&useDraft=false`
+    }
+
+    return url;
   }
 
   _loadTweets() {

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -214,11 +214,24 @@
             const hashVal = "f073a40c095e19635a4cb6ceeb8a554d0f88f55f",
               url = element._getUrl();
 
-            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}`);
+            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}&useDraft=false`);
           });
 
           test( "should account for @ character in username and ensure to remove it for computing hash", () => {
             element.username = "@RiseVision";
+
+            const hashVal = "f073a40c095e19635a4cb6ceeb8a554d0f88f55f",
+              url = element._getUrl();
+
+            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}&useDraft=false`);
+          });
+
+          test( "should not apply useDraft=false when running on Preview", () => {
+            RisePlayerConfiguration.isPreview = () => {
+              return true;
+            };
+
+            element.username = "RiseVision";
 
             const hashVal = "f073a40c095e19635a4cb6ceeb8a554d0f88f55f",
               url = element._getUrl();

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -226,7 +226,7 @@
             assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}&useDraft=false`);
           });
 
-          test( "should not apply useDraft=false when running on Preview", () => {
+          test( "should apply useDraft=true when running on Preview", () => {
             RisePlayerConfiguration.isPreview = () => {
               return true;
             };
@@ -236,7 +236,7 @@
             const hashVal = "f073a40c095e19635a4cb6ceeb8a554d0f88f55f",
               url = element._getUrl();
 
-            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}`);
+            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}&useDraft=true`);
           });
         });
 


### PR DESCRIPTION
## Description
When constructing url for request to Twitter Service, add `useDraft` as an additional query param and conditionally set Boolean value based on running on Preview or not. 

## Motivation and Context
This is required in the changes to Twitter Service. The service will use this value in its own call to core content presentation endpoint, which provides either draft or published template attribute data.  

## How Has This Been Tested?
Unit tests, manual testing will happen when Twitter Service is ready to be tested

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
