### PR TITLE
Add missing 'count' query param in request to service

### DIFF
--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -135,6 +135,8 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
       hash
     }&useDraft=${
       RisePlayerConfiguration.isPreview()
+    }&count=${
+      this.maxitems
     }`;
   }
 

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -214,7 +214,7 @@
             const hashVal = "f073a40c095e19635a4cb6ceeb8a554d0f88f55f",
               url = element._getUrl();
 
-            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}&useDraft=false`);
+            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}&useDraft=false&count=25`);
           });
 
           test( "should account for @ character in username and ensure to remove it for computing hash", () => {
@@ -223,7 +223,7 @@
             const hashVal = "f073a40c095e19635a4cb6ceeb8a554d0f88f55f",
               url = element._getUrl();
 
-            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}&useDraft=false`);
+            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}&useDraft=false&count=25`);
           });
 
           test( "should apply useDraft=true when running on Preview", () => {
@@ -236,7 +236,7 @@
             const hashVal = "f073a40c095e19635a4cb6ceeb8a554d0f88f55f",
               url = element._getUrl();
 
-            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}&useDraft=true`);
+            assert.equal(url, `https://services-stage.risevision.com/twitter/get-presentation-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&hash=${hashVal}&useDraft=true&count=25`);
           });
         });
 


### PR DESCRIPTION
## Description
Added `count` query param for request to Twitter Service `get-presentation-tweets` endpoint with the value being the `maxitems` property

## Motivation and Context
This was mistakenly left off when changes were made to target the new `get-presentation-tweets` endpoint. The request to the previous endpoint did include this param.

## How Has This Been Tested?
Unit tests, manual tests will be done once Twitter Service supports the query param

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
