### PR TITLE
Temporarily disable e2e for beta deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,8 @@ workflows:
           stage: beta
           name: deploy-beta
           requires:
-            - test-e2e-electron-beta
+            - gcloud-setup
+            - build
           filters:
             branches:
               only:


### PR DESCRIPTION
## Description
Temporarily disable e2e for beta deployment

## Motivation and Context
With the new design of `get-presentation-tweets` endpoint of Twitter Service, the component now requires the presentation id in the request to the service. 

For our e2e setup, presentation id is not available to the component as our setup has involved assigning the e2e html page as a **URL Item** in the displays schedule. Thus, the components request never gets a response as the service is failing to get presentation data from Core. 

We will revisit how to resolve in a future PR

## How Has This Been Tested?
Need to merge to master to validate

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
