### PR TITLE
Return empty url for Fetch request if presentation id is unavailable

### DIFF
--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -126,6 +126,10 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
       // TODO: encrypt username
       username = this.username && this.username.indexOf("@") === 0 ? this.username.substring(1) : this.username;
 
+    if (!presentationId || !username) {
+      return "";
+    }
+
     return `${
       config.twitterServiceURL
     }/get-tweets?presentationId=${

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -218,6 +218,18 @@
 
             assert.equal(url, `https://services-stage.risevision.com/twitter/get-tweets?presentationId=xxxx-yyyy&componentId=${element.id}&username=RiseVision&count=25`);
           });
+
+          test("should return empty url string when presentation id is falsy", () => {
+            const clone = Object.assign({}, RisePlayerConfiguration.getPresentationId);
+
+            element.username = "@RiseVision";
+
+            RisePlayerConfiguration.getPresentationId = () => {return null};
+
+            assert.equal(element._getUrl(), "");
+
+            RisePlayerConfiguration.getPresentationId = Object.assign({}, clone);
+          });
         });
 
         suite( "_handleResponse", () => {


### PR DESCRIPTION
## Description
Check for a falsy value for `presentationId` when constructing Fetch request URL and if it is falsy return an empty request url. Our Fetch mixin will do nothing if the request url is empty - https://github.com/Rise-Vision/rise-common-component/blob/master/src/fetch-mixin.js#L44-L46

## Motivation and Context
This is to prevent requests to Twitter Service without an actual presentation id query param value. 

## How Has This Been Tested?
Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
