### PR TITLE
Finalize for production

### DIFF
--- a/config/prod.js
+++ b/config/prod.js
@@ -1,3 +1,0 @@
-export const config = {
-  twitterServiceURL: "https://services.risevision.com/twitter"
-};

--- a/config/prod.js
+++ b/config/prod.js
@@ -1,3 +1,3 @@
 export const config = {
-  twitterServiceURL: "https://services-stage.risevision.com/twitter"
+  twitterServiceURL: "https://services.risevision.com/twitter"
 };

--- a/config/test.js
+++ b/config/test.js
@@ -1,3 +1,0 @@
-export const config = {
-  twitterServiceURL: "https://services-stage.risevision.com/twitter"
-};

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "description": "Rise Data Twitter component",
   "scripts": {
-    "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-twitter",
+    "prebuild": "eslint .",
     "build": "polymer build && ./node_modules/rise-common-component/scripts/extract-source.sh rise-data-twitter",
     "postbuild": "gulp",
     "pretty": "eslint . --fix",
-    "pretest": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh test rise-data-twitter",
+    "pretest": "eslint .",
     "test": "polymer test"
   },
   "repository": {

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -6,7 +6,6 @@ import { RiseElement } from "rise-common-component/src/rise-element.js";
 import { CacheMixin } from "rise-common-component/src/cache-mixin.js";
 import { FetchMixin } from "rise-common-component/src/fetch-mixin.js";
 
-import { config } from "./rise-data-twitter-config.js";
 import { version } from "./rise-data-twitter-version.js";
 
 const fetchBase = CacheMixin(RiseElement);
@@ -67,6 +66,12 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
     "BMrE1bGUIm2MDs1kwwIDAQAB" +
     "-----END PUBLIC KEY-----";
   }
+  static get SERVICE_URL_STAGING() {
+    return "https://services-stage.risevision.com/twitter";
+  }
+  static get SERVICE_URL_PROD() {
+    return "https://services.risevision.com/twitter";
+  }
 
   constructor() {
     super();
@@ -112,37 +117,17 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
     }
   }
 
-  _getTwitterServiceUrl() {
-    if (RisePlayerConfiguration.isPreview()) {
-      try {
-        const pathname = window.location.pathname;
-        const parts = pathname.split("/");
-
-        // example window location:  https://widgets.risevision.com/staging/templates/abc123/src/template.html?type=preview&presentationId=abc123
-        // pathname for above would be:  /staging/templates/abc123/src/template.html
-
-        if (parts[1] === "staging") {
-          return "https://services-stage.risevision.com/twitter"
-        }
-      } catch ( err ) {
-        console.log( "can't retrieve window location pathname", err );
-        // fallback on configured service url
-      }
-    }
-
-    return config.twitterServiceURL;
-  }
-
   _getUrl() {
     const presentationId = RisePlayerConfiguration.getPresentationId(),
-      username = this.username && this.username.indexOf("@") === 0 ? this.username.substring(1) : this.username;
+      username = this.username && this.username.indexOf("@") === 0 ? this.username.substring(1) : this.username,
+      serviceUrl = RisePlayerConfiguration.Helpers.isStaging() ? RiseDataTwitter.SERVICE_URL_STAGING : RiseDataTwitter.SERVICE_URL_PROD;
 
     if (!presentationId || !username) {
       return "";
     }
 
     return `${
-      this._getTwitterServiceUrl()
+      serviceUrl
     }/get-tweets-secure?presentationId=${
       presentationId
     }&componentId=${

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -112,9 +112,25 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
     }
   }
 
+  _getTwitterServiceUrl() {
+    if (RisePlayerConfiguration.isPreview()) {
+      try {
+        const host = top.location.host;
+
+        if (host.includes("apps-stage-")) {
+          return "https://services-stage.risevision.com/twitter"
+        }
+      } catch ( err ) {
+        console.log( "can't retrieve top location host", err );
+        // fallback on configured service url
+      }
+    }
+
+    return config.twitterServiceURL;
+  }
+
   _getUrl() {
     const presentationId = RisePlayerConfiguration.getPresentationId(),
-      // TODO: encrypt username
       username = this.username && this.username.indexOf("@") === 0 ? this.username.substring(1) : this.username;
 
     if (!presentationId || !username) {
@@ -122,7 +138,7 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
     }
 
     return `${
-      config.twitterServiceURL
+      this._getTwitterServiceUrl()
     }/get-tweets-secure?presentationId=${
       presentationId
     }&componentId=${

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -121,11 +121,12 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
         // example window location:  https://widgets.risevision.com/staging/templates/abc123/src/template.html?type=preview&presentationId=abc123
         // pathname for above would be:  /staging/templates/abc123/src/template.html
 
+        console.log("_getTwitterServiceUrl", pathname, parts, parts[0]);
         if (parts[0] === "staging") {
           return "https://services-stage.risevision.com/twitter"
         }
       } catch ( err ) {
-        console.log( "can't retrieve top location host", err );
+        console.log( "can't retrieve window location pathname", err );
         // fallback on configured service url
       }
     }

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -115,9 +115,13 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
   _getTwitterServiceUrl() {
     if (RisePlayerConfiguration.isPreview()) {
       try {
-        const host = top.location.host;
+        const pathname = window.location.pathname;
+        const parts = pathname.split("/");
 
-        if (host.includes("apps-stage-")) {
+        // example window location:  https://widgets.risevision.com/staging/templates/abc123/src/template.html?type=preview&presentationId=abc123
+        // pathname for above would be:  /staging/templates/abc123/src/template.html
+
+        if (parts[0] === "staging") {
           return "https://services-stage.risevision.com/twitter"
         }
       } catch ( err ) {

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -121,8 +121,7 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
         // example window location:  https://widgets.risevision.com/staging/templates/abc123/src/template.html?type=preview&presentationId=abc123
         // pathname for above would be:  /staging/templates/abc123/src/template.html
 
-        console.log("_getTwitterServiceUrl", pathname, parts, parts[0]);
-        if (parts[0] === "staging") {
+        if (parts[1] === "staging") {
           return "https://services-stage.risevision.com/twitter"
         }
       } catch ( err ) {

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -251,7 +251,7 @@
         suite( "_getTwitterServiceUrl", () => {
           test( "should return stage service url when running in apps stage", () => {
             sandbox.stub(RisePlayerConfiguration, "isPreview").returns(true);
-            sandbox.stub(top.location, "host").returns("apps-stage-8.risevision.com");
+            sandbox.stub(window.location, "pathname").returns("/staging/templates/abc123/src/template.html");
 
             assert.equal(element._getTwitterServiceUrl(), "https://services-stage.risevision.com/twitter");
           } );

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -46,6 +46,12 @@
             return false;
           };
 
+          RisePlayerConfiguration.Helpers = {
+            isStaging: () => {
+              return true;
+            }
+          }
+
           clock = sinon.useFakeTimers();
 
           element = fixture("test-block");
@@ -197,7 +203,7 @@
           });
 
           test("should return empty url string when presentation id is falsy", () => {
-            const clone = Object.assign({}, RisePlayerConfiguration.getPresentationId);
+            const clone = RisePlayerConfiguration.getPresentationId;
 
             element.username = "@RiseVision";
 
@@ -205,7 +211,22 @@
 
             assert.equal(element._getUrl(), "");
 
-            RisePlayerConfiguration.getPresentationId = Object.assign({}, clone);
+            RisePlayerConfiguration.getPresentationId = clone;
+          });
+
+          test("should inject production service url when is not staging", () => {
+            const clone = RisePlayerConfiguration.Helpers.isStaging;
+
+            element.username = "@RiseVision";
+
+            RisePlayerConfiguration.Helpers.isStaging = () => {return false};
+            sandbox.stub(element, "_encryptParam").returns("ABC123");
+
+            const url = element._getUrl();
+
+            assert.equal(url, `https://services.risevision.com/twitter/get-tweets-secure?presentationId=xxxx-yyyy&componentId=${element.id}&username=ABC123&count=25`);
+
+            RisePlayerConfiguration.Helpers.isStaging = clone;
           });
         });
 
@@ -246,15 +267,6 @@
             assert.isTrue(riseElement._setUptimeError.calledOnce);
             assert.isTrue(riseElement._setUptimeError.lastCall.args[0]);
           });
-        });
-
-        suite( "_getTwitterServiceUrl", () => {
-          test( "should return stage service url when running in apps stage", () => {
-            sandbox.stub(RisePlayerConfiguration, "isPreview").returns(true);
-            sandbox.stub(window.location, "pathname").returns("/staging/templates/abc123/src/template.html");
-
-            assert.equal(element._getTwitterServiceUrl(), "https://services-stage.risevision.com/twitter");
-          } );
         });
 
         suite( "logTypeForFetchError", () => {

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -248,6 +248,15 @@
           });
         });
 
+        suite( "_getTwitterServiceUrl", () => {
+          test( "should return stage service url when running in apps stage", () => {
+            sandbox.stub(RisePlayerConfiguration, "isPreview").returns(true);
+            sandbox.stub(window.location, "pathname").returns("/staging/templates/abc123/src/template.html");
+
+            assert.equal(element._getTwitterServiceUrl(), "https://services-stage.risevision.com/twitter");
+          } );
+        });
+
         suite( "logTypeForFetchError", () => {
           test( "should return error type for null error", () => {
             const eventType = element.logTypeForFetchError();

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -248,15 +248,6 @@
           });
         });
 
-        suite( "_getTwitterServiceUrl", () => {
-          test( "should return stage service url when running in apps stage", () => {
-            sandbox.stub(RisePlayerConfiguration, "isPreview").returns(true);
-            sandbox.stub(window.location, "pathname").returns("/staging/templates/abc123/src/template.html");
-
-            assert.equal(element._getTwitterServiceUrl(), "https://services-stage.risevision.com/twitter");
-          } );
-        });
-
         suite( "logTypeForFetchError", () => {
           test( "should return error type for null error", () => {
             const eventType = element.logTypeForFetchError();

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -248,6 +248,15 @@
           });
         });
 
+        suite( "_getTwitterServiceUrl", () => {
+          test( "should return stage service url when running in apps stage", () => {
+            sandbox.stub(RisePlayerConfiguration, "isPreview").returns(true);
+            sandbox.stub(top.location, "host").returns("apps-stage-8.risevision.com");
+
+            assert.equal(element._getTwitterServiceUrl(), "https://services-stage.risevision.com/twitter");
+          } );
+        });
+
         suite( "logTypeForFetchError", () => {
           test( "should return error type for null error", () => {
             const eventType = element.logTypeForFetchError();


### PR DESCRIPTION
## Description
Conditionally apply service url based on `isStaging()` function of `RisePlayerConfiguration.Helper`

## Motivation and Context
When running Apps staging, all Authentication calls to OTP (Oauth Token Provider) are targeting the staging cluster of OTP.

Since the Twitter service requires verifying credentials via OTP with the company id, the component must target the staging cluster of Twitter Service.    

## How Has This Been Tested?
Validated with Charles mapping to local file for presentation https://apps-stage-8.risevision.com/templates/edit/442f3ffd-ecb7-4c3c-958a-8401fcf2b4ae/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
