### PR TITLE
Conditionally construct service url

### DIFF
--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -34,6 +34,12 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
        */
       credentialsUpdated: {
         type: Number
+      },
+      /**
+       * A flag set to to identify if component configured from Apps Staging
+       */
+      isStaging: {
+        type: Boolean
       }
     };
   }
@@ -117,10 +123,21 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
     }
   }
 
+  _getServiceUrl() {
+    if (RisePlayerConfiguration.isPreview()) {
+      // On preview, if running in Apps staging, it is guaranteed the 'staging' version of templates are loaded, so we use the Helper function.
+      // We use Helper function instead of isStaging attribute to account for initial selection of Template and no attribute data available yet.
+      return RisePlayerConfiguration.Helpers.isStaging() ? RiseDataTwitter.SERVICE_URL_STAGING : RiseDataTwitter.SERVICE_URL_PROD;
+    } else {
+      // On a display player is guaranteed to load the 'stable' version of templates, so we need to check isStaging flag attribute.
+      return this.isStaging ? RiseDataTwitter.SERVICE_URL_STAGING : RiseDataTwitter.SERVICE_URL_PROD;
+    }
+  }
+
   _getUrl() {
     const presentationId = RisePlayerConfiguration.getPresentationId(),
       username = this.username && this.username.indexOf("@") === 0 ? this.username.substring(1) : this.username,
-      serviceUrl = RisePlayerConfiguration.Helpers.isStaging() ? RiseDataTwitter.SERVICE_URL_STAGING : RiseDataTwitter.SERVICE_URL_PROD;
+      serviceUrl = this._getServiceUrl();
 
     if (!presentationId || !username) {
       return "";

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -17,8 +17,13 @@
     <script type="text/javascript">
       RisePlayerConfiguration = {
         isConfigured: () => true,
-        getPresentationId: () => "xxxx-yyyy"
+        getPresentationId: () => "xxxx-yyyy",
+        isPreview: () => true
       };
+
+      RisePlayerConfiguration.Helpers = {
+        isStaging: () => true
+      }
     </script>
 
     <script type="module" src="../../src/rise-data-twitter.js"></script>
@@ -41,16 +46,6 @@
             warning: () => {},
             error: sinon.spy()
           };
-
-          RisePlayerConfiguration.isPreview = () => {
-            return false;
-          };
-
-          RisePlayerConfiguration.Helpers = {
-            isStaging: () => {
-              return true;
-            }
-          }
 
           clock = sinon.useFakeTimers();
 
@@ -184,7 +179,7 @@
             assert.isTrue(value.indexOf("%2B") > 0, "plus sign is encoded");
           });
 
-          test( "should build URL", () => {
+          test( "should build staging URL when running in preview in Apps staging", () => {
             element.username = "RiseVision";
             sandbox.stub(element, "_encryptParam").returns("ABC123");
 
@@ -193,11 +188,25 @@
             assert.equal(url, `https://services-stage.risevision.com/twitter/get-tweets-secure?presentationId=xxxx-yyyy&componentId=${element.id}&username=ABC123&count=25`);
           });
 
+          test( "should build production URL when running in preview in Apps production", () => {
+            const clone = RisePlayerConfiguration.Helpers.isStaging;
+
+            element.username = "RiseVision";
+            sandbox.stub(element, "_encryptParam").returns("ABC123");
+            RisePlayerConfiguration.Helpers.isStaging = () => false;
+
+            const url = element._getUrl();
+
+            assert.equal(url, `https://services.risevision.com/twitter/get-tweets-secure?presentationId=xxxx-yyyy&componentId=${element.id}&username=ABC123&count=25`);
+
+            RisePlayerConfiguration.Helpers.isStaging = clone;
+          });
+
           test( "should account for @ character in username and ensure to remove it", () => {
             element.username = "@RiseVision";
             const stub = sandbox.stub(element, "_encryptParam");
 
-            const url = element._getUrl();
+            element._getUrl();
 
             assert.isTrue(stub.calledWith('RiseVision'));
           });
@@ -214,19 +223,36 @@
             RisePlayerConfiguration.getPresentationId = clone;
           });
 
-          test("should inject production service url when is not staging", () => {
-            const clone = RisePlayerConfiguration.Helpers.isStaging;
+          test("should build staging url when running on Display and with a test/staging company", () => {
+            const cloneIsPreview = RisePlayerConfiguration.isPreview;
 
             element.username = "@RiseVision";
+            element.isStaging = true;
 
-            RisePlayerConfiguration.Helpers.isStaging = () => {return false};
+            RisePlayerConfiguration.isPreview = () => {return false};
+            sandbox.stub(element, "_encryptParam").returns("ABC123");
+
+            const url = element._getUrl();
+
+            assert.equal(url, `https://services-stage.risevision.com/twitter/get-tweets-secure?presentationId=xxxx-yyyy&componentId=${element.id}&username=ABC123&count=25`);
+
+            RisePlayerConfiguration.isPreview = cloneIsPreview;
+          });
+
+          test("should build production url when running on Display and with a production company", () => {
+            const cloneIsPreview = RisePlayerConfiguration.isPreview;
+
+            element.username = "@RiseVision";
+            element.isStaging = false;
+
+            RisePlayerConfiguration.isPreview = () => {return false};
             sandbox.stub(element, "_encryptParam").returns("ABC123");
 
             const url = element._getUrl();
 
             assert.equal(url, `https://services.risevision.com/twitter/get-tweets-secure?presentationId=xxxx-yyyy&componentId=${element.id}&username=ABC123&count=25`);
 
-            RisePlayerConfiguration.Helpers.isStaging = clone;
+            RisePlayerConfiguration.isPreview = cloneIsPreview;
           });
         });
 


### PR DESCRIPTION
## Description
When constructing service url, conditionally applying the staging or production service url based on:

- When running in Preview:
  - If `window.location.pathname` contains _staging_, then construct with staging service url, otherwise construct with production url. When running in Apps staging, it is guaranteed the 'staging' version of templates are loaded, thus making it a reliable check. We check this instead of `isStaging` attribute to account for initial selection of Template and no attribute data available yet.
- When running on a display:
  - If `isStaging` attribute is `true`, then construct with staging service url, otherwise construct with production url. On a display, player is guaranteed to load the _stable_ version of templates, so checking `isStaging` flag attribute is reliable.

These changes coincide with PR on Apps - https://github.com/Rise-Vision/rise-vision-apps/pull/1678

## Motivation and Context
Twitter component is calling production service url on a Test Company display. This is because (until these changes) the component has solely only checked for _staging_ in the `window.location.pathname`. Player always loads the _stable_ version of templates, so this check is never accurate on a display. 

## How Has This Been Tested?
Tested on Apps Stage 8 and on ChrOS display using Charles to map to local version of component. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
