### PR TITLE
Staging/cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-twitter",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Rise Data Twitter component",
   "scripts": {
     "prebuild": "eslint .",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/Rise-Vision/rise-data-twitter/#readme",
   "dependencies": {
     "jsencrypt": "^3.0.0-rc.1",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.6.1"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#702ae39"
   },
   "devDependencies": {
     "eslint-utils": ">=1.4.1",

--- a/src/rise-data-twitter.js
+++ b/src/rise-data-twitter.js
@@ -102,7 +102,7 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
     }, this._handleResponse, this._handleError);
 
     super.initCache({
-      name: this.tagName.toLowerCase(),
+      name: `${this.tagName.toLowerCase()}_v${version.charAt(0)}`,
       expiry: -1
     });
   }
@@ -134,9 +134,13 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
     }
   }
 
+  _getUsername() {
+    return this.username && this.username.indexOf("@") === 0 ? this.username.substring(1) : this.username
+  }
+
   _getUrl() {
     const presentationId = RisePlayerConfiguration.getPresentationId(),
-      username = this.username && this.username.indexOf("@") === 0 ? this.username.substring(1) : this.username,
+      username = this._getUsername(),
       serviceUrl = this._getServiceUrl();
 
     if (!presentationId || !username) {
@@ -204,6 +208,10 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
     }
   }
 
+  _getCacheKey() {
+    return `${this._getUsername()}_${this.maxitems}`;
+  }
+
   logTypeForFetchError(error) {
     if (!error || !error.status) {
       return RiseDataTwitter.LOG_TYPE_ERROR;
@@ -226,6 +234,14 @@ export default class RiseDataTwitter extends FetchMixin(fetchBase) {
     }
 
     return RiseDataTwitter.LOG_TYPE_ERROR;
+  }
+
+  getCacheRequestKey() {
+    return this._getCacheKey();
+  }
+
+  putCacheRequestKey() {
+    return this._getCacheKey();
   }
 
 }

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -167,6 +167,20 @@
           });
         });
 
+        suite( "_getUsername", () => {
+          test( "should return username", () => {
+            element.username = "test";
+
+            assert.equal(element._getUsername(), "test");
+          });
+
+          test( "should account for @ character in username and ensure to remove it", () => {
+            element.username = "@RiseVision";
+
+            assert.equal(element._getUsername(), "RiseVision");
+          });
+        } );
+
         suite( "_getUrl", () => {
           test( "should encrypt value", () => {
             const value = element._encryptParam("abc");
@@ -200,15 +214,6 @@
             assert.equal(url, `https://services.risevision.com/twitter/get-tweets-secure?presentationId=xxxx-yyyy&componentId=${element.id}&username=ABC123&count=25`);
 
             RisePlayerConfiguration.Helpers.isStaging = clone;
-          });
-
-          test( "should account for @ character in username and ensure to remove it", () => {
-            element.username = "@RiseVision";
-            const stub = sandbox.stub(element, "_encryptParam");
-
-            element._getUrl();
-
-            assert.isTrue(stub.calledWith('RiseVision'));
           });
 
           test("should return empty url string when presentation id is falsy", () => {
@@ -255,6 +260,14 @@
             RisePlayerConfiguration.isPreview = cloneIsPreview;
           });
         });
+
+        suite( "_getCacheKey", () => {
+          test( "should return cache key using username and maxitems", () => {
+            element.username = "test";
+
+            assert.equal(element._getCacheKey(), "test_25");
+          });
+        } );
 
         suite( "_handleResponse", () => {
           test( "should handle a valid JSON response", () => {


### PR DESCRIPTION
## Description
Overriding cache-mixin `getCacheRequestKey` and `putCacheRequestKey` functions so a custom request key can be provided instead of the request url. 

Refactored some code to avoid DRY 

Corresponding PR for this is https://github.com/Rise-Vision/rise-common-component/pull/42

## Motivation and Context
Twitter component needs a custom cache key because every request to Twitter service that it makes consists of query params that can and will have different values per each request particularly because of the encrypted String value of _username_. Also, given presentation id is in the request, different presentations in a schedule won't access the same cache if _username_ is the same because the presentation ids are different. This all defeats the purpose of using Cache API and will pollute the cache with unused entries.

The ability to customize the cache request key to pair with the response solves this problem.

## How Has This Been Tested?
Tested on Electron Player (VB Windows 10 x32) using Charles to map to local version of twitter component

https://www.screencast.com/t/jsQKAXVGKHyZ

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
