### PR TITLE
Add new dist file that points to polymer-bundle.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,13 +1,20 @@
+const concat = require("gulp-concat");
 
 const gulp = require("gulp");
-const fs = require("fs");
-const header = require("gulp-header");
 
-const bundles = "dist/rise-data-twitter*.js";
-const dependency = "node_modules/jsencrypt/bin/jsencrypt.min.js";
+const bundles = [ 
+	"dist/rise-data-twitter.js", 
+	"dist/rise-data-twitter-bundle.min.js"
+];
+const dependencies = [
+  "node_modules/jsencrypt/bin/jsencrypt.min.js"
+];
 
-gulp.task( "default", () => {
-  return gulp.src( bundles )
-    .pipe( header( fs.readFileSync(dependency) ) )
-    .pipe( gulp.dest( "dist/" ) );
+gulp.task( "default", (done) => {
+  bundles.map(function(file) {
+    return gulp.src( dependencies.concat( file ) )
+      .pipe( concat( file ) )
+      .pipe( gulp.dest( "." ) );
+  });
+  done();
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,13 +1,13 @@
-const concat = require("gulp-concat");
-const gulp = require("gulp");
 
-const bundle = "dist/rise-data-twitter.js";
-const dependencies = [
-  "node_modules/jsencrypt/bin/jsencrypt.min.js"
-];
+const gulp = require("gulp");
+const fs = require("fs");
+const header = require("gulp-header");
+
+const bundles = "dist/rise-data-twitter*.js";
+const dependency = "node_modules/jsencrypt/bin/jsencrypt.min.js";
 
 gulp.task( "default", () => {
-  return gulp.src( dependencies.concat(bundle) )
-    .pipe( concat( bundle ) )
-    .pipe( gulp.dest( "." ) );
+  return gulp.src( bundles )
+    .pipe( header( fs.readFileSync(dependency) ) )
+    .pipe( gulp.dest( "dist/" ) );
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-twitter",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Rise Data Twitter component",
   "scripts": {
     "prebuild": "eslint .",
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/Rise-Vision/rise-data-twitter/#readme",
   "dependencies": {
     "jsencrypt": "^3.0.0-rc.1",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.1"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.2"
   },
   "devDependencies": {
     "eslint-utils": ">=1.4.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "devDependencies": {
     "eslint-utils": ">=1.4.1",
     "gulp": "^4.0.2",
-    "gulp-header": "^2.0.9"
+    "gulp-concat": "^2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "devDependencies": {
     "eslint-utils": ">=1.4.1",
     "gulp": "^4.0.2",
-    "gulp-concat": "^2.6.1"
+    "gulp-header": "^2.0.9"
   }
 }


### PR DESCRIPTION
## Description
Adds an extra distribution file that references a static version of polymer and dependencies instead of relative to the template.

## Motivation and Context
Please check notes from: https://github.com/Rise-Vision/rise-common-component/pull/73

## How Has This Been Tested?
Confirmed the file exists and points to the static polymer-bundle: 
https://widgets.risevision.com/staging/components/rise-data-twitter/build-bundle/rise-data-twitter-bundle.min.js

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alexdeaconu Please review. 
@stulees @olegrise fyi