### PR TITLE
Log appropriate error codes according to status code for a request error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-twitter",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,21 +13,21 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-      "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog=="
+      "version": "7.13.11",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.11.tgz",
+      "integrity": "sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg=="
     },
     "@babel/core": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.8.tgz",
-      "integrity": "sha512-oYapIySGw1zGhEFRd6lzWNLWFX2s5dA/jm+Pw/+59ZdXtjyIuwlXbrId22Md0rgZVop+aVoqow2riXhBLNyuQg==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
+      "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
-        "@babel/helper-compilation-targets": "^7.13.8",
+        "@babel/generator": "^7.13.9",
+        "@babel/helper-compilation-targets": "^7.13.10",
         "@babel/helper-module-transforms": "^7.13.0",
-        "@babel/helpers": "^7.13.0",
-        "@babel/parser": "^7.13.4",
+        "@babel/helpers": "^7.13.10",
+        "@babel/parser": "^7.13.10",
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.0",
@@ -51,9 +51,9 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
-      "integrity": "sha512-pBljUGC1y3xKLn1nrx2eAhurLMA8OqBtBP/JwG4U8skN7kf8/aqwwxpV1N6T0e7r6+7uNitIa/fUxPFagSXp3A==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
+      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
       "requires": {
         "@babel/compat-data": "^7.13.8",
         "@babel/helper-validator-option": "^7.12.17",
@@ -162,9 +162,9 @@
       "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
     },
     "@babel/helpers": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
-      "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
+      "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
       "requires": {
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
@@ -172,9 +172,9 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
-      "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
@@ -182,9 +182,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
-      "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw=="
+      "version": "7.13.11",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.11.tgz",
+      "integrity": "sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q=="
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -290,15 +290,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@sinonjs/formatio": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
-      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
-      "requires": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^5.0.2"
-      }
-    },
     "@sinonjs/samsam": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
@@ -320,9 +311,9 @@
       "integrity": "sha512-9Iseu8bRtecb0klvv+WXZOVZatsRkbaH7M97Z+f+Pt909R4lDfgUODAnra23DOZTpeMTAkVpf4m/FZztN7Ox1A=="
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.4.tgz",
-      "integrity": "sha512-UWXZYbaDLLfhm+xONXTiDciyhOSwKRrZieGQHFMSMGSxY4mbjZ5uYzOKgnuX0luYFvjJw32G3r0sCwQZPJIR4Q=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
+      "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg=="
     },
     "acorn": {
       "version": "7.4.1",
@@ -1056,9 +1047,9 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001197",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
-      "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw=="
+      "version": "1.0.30001203",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001203.tgz",
+      "integrity": "sha512-/I9tvnzU/PHMH7wBPrfDMSuecDeUKerjCPX7D0xBbaJZPxoT9m+yYxt0zCTkcijCkjTdim3H56Zm0i5Adxch4w=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -1373,9 +1364,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.14.tgz",
-      "integrity": "sha512-nEQqCHzxiFfu1dEHYxe7xrbF5vFmx122mTWIM+BkiAOmsWbSAcucNk8stELnNk2lS1biTUjFOCIf8v8ZN225IA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
+      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
       "requires": {
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
@@ -1609,9 +1600,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.683",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.683.tgz",
-      "integrity": "sha512-8mFfiAesXdEdE0DhkMKO7W9U6VU/9T3VTWwZ+4g84/YMP4kgwgFtQgUxuu7FUMcvSeKSNhFQNU+WZ68BQTLT5A=="
+      "version": "1.3.692",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.692.tgz",
+      "integrity": "sha512-Ix+zDUAXWZuUzqKdhkgN5dP7ZM+IwMG4yAGFGDLpGJP/3vNEEwuHG1LIhtXUfW0FFV0j38t5PUv2n/3MFSRviQ=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -5206,9 +5197,9 @@
       }
     },
     "mocha": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
-      "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
       "requires": {
         "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
@@ -6234,17 +6225,17 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#db930a0e89e780598478280e5a39f7f616b77980",
-      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.8.3",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#0b91d42f33bcbf84aa669b00473d61365061e154",
+      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.3",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@polymer/test-fixture": "~4.0.2",
-        "@webcomponents/webcomponentsjs": "~2.4.2",
+        "@webcomponents/webcomponentsjs": "^2.4.4",
         "chai": "~4.2.0",
-        "coveralls": "~3.0.9",
+        "coveralls": "^3.0.14",
         "eslint": "~6.8.0",
-        "mocha": "~7.1.0",
-        "sinon": "~9.0.0",
+        "mocha": "^7.1.2",
+        "sinon": "^9.0.3",
         "wct-istanbul": "~0.14.3",
         "wct-mocha": "~1.0.1"
       }
@@ -6342,14 +6333,13 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "sinon": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
-      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
       "requires": {
-        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/formatio": "^5.0.1",
-        "@sinonjs/samsam": "^5.1.0",
+        "@sinonjs/samsam": "^5.3.1",
         "diff": "^4.0.2",
         "nise": "^4.0.4",
         "supports-color": "^7.1.0"
@@ -6955,9 +6945,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.0.tgz",
-      "integrity": "sha512-TWYSWa9T2pPN4DIJYbU9oAjQx+5qdV5RUDxwARg8fmJZrD/V27Zj0JngW5xg1DFz42G0uDYl2XhzF6alSzD62w==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.1.tgz",
+      "integrity": "sha512-EWhx3fHy3M9JbaeTnO+rEqzCe1wtyQClv6q3YWq0voOj4E+bMZBErVS1GAHPDiRGONYq34M1/d8KuQMgvi6Gjw==",
       "optional": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-twitter",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Rise Data Twitter component",
   "scripts": {
     "prebuild": "eslint .",
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/Rise-Vision/rise-data-twitter/#readme",
   "dependencies": {
     "jsencrypt": "^3.0.0-rc.1",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.2"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.3"
   },
   "devDependencies": {
     "eslint-utils": ">=1.4.1",

--- a/test/unit/rise-data-twitter.html
+++ b/test/unit/rise-data-twitter.html
@@ -56,6 +56,7 @@
 
           sandbox.spy(riseElement, '_sendEvent');
           sandbox.stub(riseElement, '_setUptimeError');
+          sandbox.stub(riseElement, 'log');
         });
 
         teardown(()=>{
@@ -311,71 +312,54 @@
           });
         });
 
-        suite( "logTypeForFetchError", () => {
-          test( "should return error type for null error", () => {
-            const eventType = element.logTypeForFetchError();
-
-            assert.equal(eventType, "error");
+        suite( "_errorCodeForFetchError", () => {
+          test( "should return E000000037 with no status", () => {
+            assert.equal(element._errorCodeForFetchError(), "E000000037");
+            assert.equal(element._errorCodeForFetchError({}), "E000000037");
+            assert.equal(element._errorCodeForFetchError({status: 0}), "E000000037");
           });
 
-          test( "should return error type for error with no status", () => {
-            const eventType = element.logTypeForFetchError({});
-
-            assert.equal(eventType, "error");
+          test( "should return E000000095 for a 400 Bad Request", () => {
+            assert.equal(element._errorCodeForFetchError({status: 400}), "E000000095");
           });
 
-          test( "should return warning type for 403 status", () => {
-            const eventType = element.logTypeForFetchError({ status: 403 });
-
-            assert.equal(eventType, "warning");
+          test( "should return E000000096 for a 403 Forbidden error", () => {
+            assert.equal(element._errorCodeForFetchError({status: 403}), "E000000096");
           });
 
-          test( "should return warning type for 429 status", () => {
-            const eventType = element.logTypeForFetchError({ status: 429 });
-
-            assert.equal(eventType, "warning");
+          test( "should return E000000099 for a 404 Not Found error pertaining to user name", () => {
+            assert.equal(element._errorCodeForFetchError({status: 404, responseText: "Username not found: test"}), "E000000099");
           });
 
-          test( "should return error type for 404 status with no response text", () => {
-            const eventType = element.logTypeForFetchError({ status: 404 });
-
-            assert.equal(eventType, "error");
+          test( "should return E000000097 for a 409 Too Many Requests error", () => {
+            assert.equal(element._errorCodeForFetchError({status: 429}), "E000000097");
           });
 
-          test( "should return warning type for 404 status with username not found", () => {
-            const eventType = element.logTypeForFetchError({
-              status: 404,
-              responseText: "Username not found: 'panchito'"
-            });
-
-            assert.equal(eventType, "warning");
+          test( "should return E000000098 for an unexpected Twitter Service error", () => {
+            // server error
+            assert.equal(element._errorCodeForFetchError({status: 500}), "E000000098");
+            // when presentation data not found from Core with the presentation id used in request
+            assert.equal(element._errorCodeForFetchError({status: 404}), "E000000098");
+            // a concurrent request for user timeline is loading and is severely delayed in completing
+            assert.equal(element._errorCodeForFetchError({status: 409}), "E000000098");
+            // unaccount for status
+            assert.equal(element._errorCodeForFetchError({status: 503}), "E000000098");
           });
 
-          test( "should return error type for 404 status with page not found", () => {
-            const eventType = element.logTypeForFetchError({
-              status: 404,
-              responseText: "Page not found"
-            });
+        } );
 
-            assert.equal(eventType, "error");
+        suite( "logFetchError", () => {
+          test( "should log warning when offline", () => {
+            element.logFetchError({isOffline: true, status: 0});
+            assert.isTrue(riseElement.log.calledWith("warning", "client offline", null, {error: null}));
           });
 
-          test( "should return error type for 500 status", () => {
-            const eventType = element.logTypeForFetchError({ status: 500 });
+          test( "should log error when online", () => {
+            element.logFetchError();
+            assert.isTrue(riseElement.log.calledWith("error", "request error", {errorCode: "E000000037"}, {error: null}));
 
-            assert.equal(eventType, "error");
-          });
-
-          test( "should return error type for 400 status", () => {
-            const eventType = element.logTypeForFetchError({ status: 400 });
-
-            assert.equal(eventType, "error");
-          });
-
-          test( "should return error type for 409 status", () => {
-            const eventType = element.logTypeForFetchError({ status: 409 });
-
-            assert.equal(eventType, "error");
+            element.logFetchError({message: "Request rejected with status 400", status: 400, responseText: "Company id was not provided"});
+            assert.isTrue(riseElement.log.calledWith("error", "request error", {errorCode: "E000000095"}, {error: "Request rejected with status 400", status: 400, responseText: "Company id was not provided"}));
           });
         });
 


### PR DESCRIPTION
## Description
Overriding fetch-mixin function `logFetchError()` in order to customize logging errors.

All request errors now log an error to BQ. None of them are being filtered for a warning anymore. 

Ensuring to log appropriate error codes according to status code as per the approved Uptime Error Definitions.

## Motivation and Context
Uptime Standards

## How Has This Been Tested?
Locally via Charles mapping to local version of twitter component. Validated by running this presentation https://apps.risevision.com/templates/edit/049a1052-4570-479e-804b-a68c52668019/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f in ChrOS Player and shared schedule and forced error situations that could be forced. 

For example, validated a username that does not exist was logged correctly to BQ after all Fetch request retries were exhausted (5 retries)

![image](https://user-images.githubusercontent.com/7407007/111803699-ac804180-88a5-11eb-9448-cc67ee7394bd.png)


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
