### PR TITLE
Fix e2e test - use production display ID

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ workflows:
               only:
                 - build/stable
       - test-e2e-electron:
-          displayId: Z8RSGWXE8KR8
+          displayId: FR8H572DPG3W
           installerPath: /beta/
           name: test-e2e-electron-beta
           requires:


### PR DESCRIPTION
## Description
The display ID was temporary changed in the PR https://github.com/Rise-Vision/rise-data-twitter/pull/13 to the stage display ID. This PR puts the production Display ID back. Something has changed either in Viewer or Common Template and as a result Player no longer renders beta content content correctly if stage display ID is used.

## Motivation and Context
E2e test `test-e2e-electron-beta` failing.

## How Has This Been Tested?
Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
